### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,5 +9,7 @@ jobs:
   update-majorver:
     name: Update Major Version Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: nowactions/update-majorver@f2014bbbba95b635e990ce512c5653bd0f4753fb


### PR DESCRIPTION
Potential fix for [https://github.com/zgosalvez/github-actions-analyze-dart/security/code-scanning/3](https://github.com/zgosalvez/github-actions-analyze-dart/security/code-scanning/3)

In general, to fix this class of problem you must add an explicit `permissions` block either at the top level of the workflow (applying to all jobs) or within the specific job, granting only the minimal access the job requires. For workflows that interact with repository contents (e.g., updating tags, pushing commits), the `contents: write` scope is typically necessary. If a workflow only needs to read the repo, `contents: read` is sufficient.

For this specific workflow (`.github/workflows/version.yml`), the `update-majorver` job uses `nowactions/update-majorver` to update the “major version” tag when a tag like `v1.2.3` is pushed. That implies it must modify Git refs in the repository, which requires `contents: write` on the `GITHUB_TOKEN`. The least‑privilege, non‑breaking fix is to add a `permissions` block to the `update-majorver` job specifying `contents: write` and nothing else. We do not need to alter any steps or add additional jobs.

Concretely:
- Edit `.github/workflows/version.yml`.
- Under `jobs:`, within the `update-majorver` job definition (near line 10), insert a `permissions:` section between `runs-on: ubuntu-latest` and `steps:`:
  ```yaml
  permissions:
    contents: write
  ```
- No additional imports, methods, or definitions are required because this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
